### PR TITLE
new httpbin image with nginx unit + env tags

### DIFF
--- a/03-sidecar/nginxp-sidecar/httpbin-api/httpbin-api-sc-nginxp-deploy.yml
+++ b/03-sidecar/nginxp-sidecar/httpbin-api/httpbin-api-sc-nginxp-deploy.yml
@@ -42,8 +42,13 @@ spec:
           mountPath: /etc/nginx/nginx.conf
           subPath: nginx.conf
       - name: httpbin-api-apps
-        image: kennethreitz/httpbin
+        image: simonkowallik/httpbin:unit
         imagePullPolicy: IfNotPresent
+        env:
+        - name: XHTTPBIN_X-F5+NGINX
+          value: "Better together"
+        - name: HTTPBIN_F5+NGINX
+          value: "Better together"
         ports:
         - containerPort: 80
       - name: fluentd


### PR DESCRIPTION
- Use an alternative and more recent httpbin image
- Image uses nginx unit 1.13.0
- Adds environment variables to enable:
  - custom "X-F5+NGINX" HTTP header in responses
  - "F5+NGINX" tag when requesting /tags